### PR TITLE
fix NeoForge for 1.20.5/6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
     id "dev.architectury.loom" version "1.6-SNAPSHOT" apply false
     id "me.shedaniel.unified-publishing" version "0.1.+" apply false
+    id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
 }
 
 architectury {
@@ -14,7 +15,10 @@ subprojects {
     dependencies {
         minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
         // The following line declares the yarn mappings you may select this one as well.
-        mappings "net.fabricmc:yarn:${rootProject.yarn_mappings}:v2"
+        mappings loom.layered {
+            it.mappings("net.fabricmc:yarn:$rootProject.yarn_mappings:v2")
+            it.mappings("dev.architectury:yarn-mappings-patch-neoforge:$rootProject.yarn_mappings_patch_neoforge_version")
+        }
     }
 }
 

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.github.johnrengelman.shadow" version "7.1.2"
+    id 'com.github.johnrengelman.shadow'
     id "me.shedaniel.unified-publishing"
 }
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx4096M
 
 minecraft_version=1.20.6
 yarn_mappings=1.20.6+build.1
-enabled_platforms=fabric
+enabled_platforms=fabric,neoforge
 
 archives_base_name=midnightlib
 mod_version=1.5.5
@@ -14,7 +14,8 @@ modrinth_id=codAaoxh
 fabric_loader_version=0.15.11
 fabric_api_version=0.97.8+1.20.6
 
-neoforge_version=20.6.30-beta
+neoforge_version=20.6.63-beta
+yarn_mappings_patch_neoforge_version = 1.20.5+build.3
 
 quilt_loader_version=0.19.0-beta.18
 quilt_fabric_api_version=7.0.1+0.83.0-1.20

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -1,9 +1,14 @@
 plugins {
-    id "com.github.johnrengelman.shadow" version "7.1.2"
+    id 'com.github.johnrengelman.shadow'
 }
-repositories{
-    maven {url "https://maven.neoforged.net/releases"}
+
+repositories {
+    maven {
+        name = 'NeoForged'
+        url = 'https://maven.neoforged.net/releases'
+    }
 }
+
 
 architectury {
     platformSetupLoomIde()
@@ -15,41 +20,44 @@ loom {
 }
 
 configurations {
-    common
-    shadowCommon // Don't use shadow from the shadow plugin because we don't want IDEA to index this.
+    common {
+        canBeResolved = true
+        canBeConsumed = false
+    }
     compileClasspath.extendsFrom common
     runtimeClasspath.extendsFrom common
-    developmentForge.extendsFrom common
-    archivesBaseName = rootProject.archives_base_name + "-neoforge"
+    developmentNeoForge.extendsFrom common
+
+    // Files in this configuration will be bundled into your mod using the Shadow plugin.
+    // Don't use the `shadow` configuration from the plugin itself as it's meant for excluding files.
+    shadowBundle {
+        canBeResolved = true
+        canBeConsumed = false
+    }
 }
 
 dependencies {
-    neoForge "net.neoforged:neoforge:${rootProject.neoforge_version}"
+    neoForge "net.neoforged:neoforge:$rootProject.neoforge_version"
 
-    common(project(path: ":common", configuration: "namedElements")) { transitive false }
-    shadowCommon(project(path: ":common", configuration: "transformProductionNeoForge")) { transitive = false }
+    common(project(path: ':common', configuration: 'namedElements')) { transitive false }
+    shadowBundle project(path: ':common', configuration: 'transformProductionNeoForge')
 }
 
 processResources {
-    inputs.property "version", project.version
+    inputs.property 'version', project.version
 
-    filesMatching("META-INF/mods.toml") {
-        expand "version": project.version
+    filesMatching('META-INF/neoforge.mods.toml') {
+        expand version: project.version
     }
 }
 
 shadowJar {
-    exclude "fabric.mod.json"
-    exclude "architectury.common.json"
-
-    configurations = [project.configurations.shadowCommon]
-    archiveClassifier = "dev-shadow"
+    configurations = [project.configurations.shadowBundle]
+    archiveClassifier = 'dev-shadow'
 }
 
 remapJar {
-    atAccessWideners.add('midnightlib.accesswidener')
     input.set shadowJar.archiveFile
-    dependsOn shadowJar
 }
 
 sourcesJar {

--- a/neoforge/src/main/java/eu/midnightdust/neoforge/MidnightLibNeoForge.java
+++ b/neoforge/src/main/java/eu/midnightdust/neoforge/MidnightLibNeoForge.java
@@ -2,48 +2,43 @@ package eu.midnightdust.neoforge;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import eu.midnightdust.core.MidnightLib;
-import eu.midnightdust.core.screen.MidnightConfigOverviewScreen;
 import eu.midnightdust.lib.config.AutoCommand;
 import eu.midnightdust.lib.config.MidnightConfig;
 import net.minecraft.server.command.ServerCommandSource;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.IExtensionPoint;
 import net.neoforged.fml.ModList;
-import net.neoforged.fml.ModLoadingContext;
+import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.fml.loading.FMLEnvironment;
-import net.neoforged.neoforge.client.ConfigScreenHandler;
-import net.neoforged.neoforge.client.event.ScreenEvent;
+import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
-
-import static net.neoforged.fml.IExtensionPoint.DisplayTest.IGNORESERVERONLY;
 
 @Mod("midnightlib")
 public class MidnightLibNeoForge {
     public MidnightLibNeoForge() {
-        ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> IGNORESERVERONLY, (remote, server) -> true));
-        if (FMLEnvironment.dist == Dist.CLIENT) MidnightLib.onInitializeClient(); else MidnightLib.onInitializeServer();
+        if (FMLEnvironment.dist == Dist.CLIENT) MidnightLib.onInitializeClient();
+        else MidnightLib.onInitializeServer();
     }
-    @Mod.EventBusSubscriber(modid = "midnightlib", bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+
+    @EventBusSubscriber(modid = "midnightlib", bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
     public static class MidnightLibBusEvents {
         @SubscribeEvent
         public static void onPostInit(FMLClientSetupEvent event) {
             ModList.get().forEachModContainer((modid, modContainer) -> {
                 if (MidnightConfig.configClass.containsKey(modid)) {
-                    modContainer.registerExtensionPoint(ConfigScreenHandler.ConfigScreenFactory.class, () ->
-                            new ConfigScreenHandler.ConfigScreenFactory((client, parent) -> MidnightConfig.getScreen(parent, modid)));
+                    modContainer.registerExtensionPoint(IConfigScreenFactory.class, (minecraftClient, screen) -> MidnightConfig.getScreen(screen, modid));
                 }
             });
         }
     }
 
-    @Mod.EventBusSubscriber(modid = "midnightlib", value = Dist.DEDICATED_SERVER)
+    @EventBusSubscriber(modid = "midnightlib", value = Dist.DEDICATED_SERVER)
     public static class MidnightLibServerEvents {
         @SubscribeEvent
         public static void registerCommands(RegisterCommandsEvent event) {
-            for (LiteralArgumentBuilder<ServerCommandSource> command : AutoCommand.commands){
+            for (LiteralArgumentBuilder<ServerCommandSource> command : AutoCommand.commands) {
                 event.getDispatcher().register(command);
             }
         }

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml"
-loaderVersion = "[1,)"
+loaderVersion = "[2,)"
 #issueTrackerURL = ""
 license = "MIT License"
 
@@ -17,13 +17,13 @@ Common Library for Team MidnightDust's mods.
 [[dependencies.midnightlib]]
 modId = "neoforge"
 mandatory = true
-versionRange = "[20.3,)"
+versionRange = "[20.5,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.midnightlib]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[1.20.3,)"
+versionRange = "[1.20.5,)"
 ordering = "NONE"
 side = "BOTH"

--- a/neoforge/src/main/resources/pack.mcmeta
+++ b/neoforge/src/main/resources/pack.mcmeta
@@ -1,6 +1,0 @@
-{
-  "pack": {
-    "description": "MidnightLib",
-    "pack_format": 22
-  }
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,6 @@ include("common")
 include("fabric-like")
 include("fabric")
 //include("quilt")
-//include("neoforge")
+include("neoforge")
 
 rootProject.name = "midnightlib"


### PR DESCRIPTION
This allows the mod to compile and run on NeoForge for 1.20.6. Tested against my MoreMouseKeybinds mod.

Note: DisplayTest was removed because it was removed from NeoForge itself, I'm unaware of any alternative right now.