### PR TITLE
1.6.2-rc.1 fileChooser uses the icon of the target mod

### DIFF
--- a/common/src/main/java/eu/midnightdust/lib/util/MidnightFileChooser.java
+++ b/common/src/main/java/eu/midnightdust/lib/util/MidnightFileChooser.java
@@ -1,0 +1,27 @@
+package eu.midnightdust.lib.util;
+
+import javax.swing.JFileChooser;
+import javax.swing.JDialog;
+import javax.swing.ImageIcon;
+import java.awt.Component;
+import java.awt.HeadlessException;
+
+/**
+ * This class is used create a file chooser dialog with the icon of the target mod.<br>
+ * <code>MidnightFileChooser fileChooser = new MidnightFileChooser("currentDirectoryPath", "modid");</code>
+ */
+public class MidnightFileChooser extends JFileChooser {
+    final ImageIcon icon;
+
+    public MidnightFileChooser(String currentDirectoryPath, String modid) {
+        super(currentDirectoryPath);
+        this.icon = MidnightIconUnit.of(modid).getIcon();
+    }
+
+    @Override
+    protected JDialog createDialog(Component parent) throws HeadlessException {
+        JDialog dialog = super.createDialog(parent);
+        dialog.setIconImage(icon.getImage());
+        return dialog;
+    }
+}

--- a/common/src/main/java/eu/midnightdust/lib/util/MidnightIconUnit.java
+++ b/common/src/main/java/eu/midnightdust/lib/util/MidnightIconUnit.java
@@ -1,0 +1,57 @@
+package eu.midnightdust.lib.util;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.util.Objects;
+import java.util.Optional;
+
+import static eu.midnightdust.core.MidnightLib.MOD_ID;
+
+
+/**
+ * This class is used to get the icon of any mod.<br>
+ * <code>ImageIcon icon = MidnightIconUnit.of("modid").getIcon();</code>
+ */
+public class MidnightIconUnit {
+    ModContainer modContainer;
+
+    protected MidnightIconUnit(String modid) {
+        modContainer = FabricLoader.getInstance().getModContainer(modid).orElse(
+                FabricLoader.getInstance().getModContainer(MOD_ID).orElse(null)
+        );
+    }
+
+    private @NotNull String getIconPath() {
+        if (modContainer != null) {
+            int [] sizes = {8, 16, 32, 48, 64, 96, 128, 256, 512};
+            String iconPath = null;
+            for (int size : sizes) {
+                Optional<String> icon = modContainer.getMetadata().getIconPath(size);
+                if (icon.isPresent()) {
+                    iconPath = icon.get();     // "assets/modid/.../xxx.png"
+                    break;
+                }
+            }
+            iconPath = "/" + iconPath;         // "/assets/modid/.../xxx.png"
+            return iconPath;
+        } else {
+            return "/assets/" + MOD_ID + "/icon.png";
+        }
+    }
+
+    public ImageIcon getIcon() {
+        return new ImageIcon(Objects.requireNonNullElse(
+                MidnightIconUnit.class.getResource(this.getIconPath()),
+                MidnightIconUnit.class.getResource("/assets/" + MOD_ID + "/icon.png")
+        ));
+    }
+
+    @Contract("_ -> new")
+    public static @NotNull MidnightIconUnit of(String modid) {
+        return new MidnightIconUnit(modid);
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ yarn_mappings=1.21+build.1
 enabled_platforms=fabric,neoforge
 
 archives_base_name=midnightlib
-mod_version=1.6.1
+mod_version=1.6.2-rc.1
 maven_group=eu.midnightdust
 release_type=release
 curseforge_id=488090

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/test-fabric/src/main/java/eu/midnightdust/fabric/example/config/MidnightConfigExample.java
+++ b/test-fabric/src/main/java/eu/midnightdust/fabric/example/config/MidnightConfigExample.java
@@ -42,26 +42,26 @@ public class MidnightConfigExample extends MidnightConfig {
     @Entry(category = LISTS, name = "I am a float list!") public static List<Float> floatList = Lists.newArrayList(4.1f, -1.3f, -1f);
 
     @Entry(category = FILES,
-            selectionMode = JFileChooser.FILES_ONLY,
+            fileSelectionMode = JFileChooser.FILES_ONLY,
             fileExtensions = {"json", "txt", "log"}, // Define valid file extensions
             fileChooserType = JFileChooser.SAVE_DIALOG,
             name = "I am a file!")
     public static String myFile = ""; // The isFile property adds a file picker button
 
     @Entry(category = FILES,
-            selectionMode = JFileChooser.DIRECTORIES_ONLY,
+            fileSelectionMode = JFileChooser.DIRECTORIES_ONLY,
             fileChooserType = JFileChooser.OPEN_DIALOG,
             name = "I am a directory!")
     public static String myDirectory = ""; // The isDirectory property adds a directory picker button
 
     @Entry(category = FILES,
-            selectionMode = JFileChooser.FILES_AND_DIRECTORIES,
+            fileSelectionMode = JFileChooser.FILES_AND_DIRECTORIES,
             fileExtensions = {"png", "jpg", "jpeg"},
             fileChooserType = JFileChooser.OPEN_DIALOG,
             name = "I can choose both files & directories!")
     public static String myFileOrDirectory = ""; // The isFileOrDirectory property adds a file or directory picker button
     @Entry(category = FILES,
-            selectionMode = JFileChooser.FILES_AND_DIRECTORIES,
+            fileSelectionMode = JFileChooser.FILES_AND_DIRECTORIES,
             fileExtensions = {"png", "jpg", "jpeg"},
             fileChooserType = JFileChooser.OPEN_DIALOG,
             name = "I am a mf file/directory list!")


### PR DESCRIPTION
<img width="191" alt="s2024-08-30 120818" src="https://github.com/user-attachments/assets/e4e1d9a1-8440-4485-98ec-56ff57afff3e">
<img width="227" alt="s2024-08-30 120947" src="https://github.com/user-attachments/assets/9fba1cd8-a311-4b85-83cc-b2bf24382994">

The file selector now uses the target mod's icon by default, or the midnightlib icon if there is no icon available.