### PR TITLE
1.7.2-rc.2

### DIFF
--- a/common/src/main/java/eu/midnightdust/lib/config/MidnightConfig.java
+++ b/common/src/main/java/eu/midnightdust/lib/config/MidnightConfig.java
@@ -5,7 +5,9 @@ import com.google.gson.*; import com.google.gson.stream.*;
 import eu.midnightdust.lib.util.PlatformFunctions;
 import net.fabricmc.api.EnvType; import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient; import net.minecraft.client.font.TextRenderer; import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.Element; import net.minecraft.client.gui.Selectable; import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.Element; import net.minecraft.client.gui.Selectable;
+import net.minecraft.client.gui.screen.ConfirmLinkScreen;
+import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.tab.GridScreenTab; import net.minecraft.client.gui.tab.Tab; import net.minecraft.client.gui.tab.TabManager;
 import net.minecraft.client.gui.tooltip.Tooltip; import net.minecraft.client.gui.widget.*;
 import net.minecraft.client.render.RenderLayer;
@@ -14,6 +16,7 @@ import net.minecraft.registry.Registries;
 import net.minecraft.screen.ScreenTexts;
 import net.minecraft.text.Style; import net.minecraft.text.Text;
 import net.minecraft.util.Formatting; import net.minecraft.util.Identifier;
+import net.minecraft.util.Util;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*; import javax.swing.filechooser.FileNameExtensionFilter;
@@ -488,6 +491,20 @@ public abstract class MidnightConfig {
                 }
             }
         }
+
+        @Override
+        public boolean mouseClicked(double mouseX, double mouseY, int button) {
+            boolean result = super.mouseClicked(mouseX, mouseY, button);
+            if (this.info != null && this.info.comment != null && !this.info.comment.url().isBlank()) {
+                Screen parent = MinecraftClient.getInstance().currentScreen;
+                MinecraftClient.getInstance().setScreen(new ConfirmLinkScreen((confirm)->{
+                    if (confirm) Util.getOperatingSystem().open(this.info.comment.url());
+                    MinecraftClient.getInstance().setScreen(parent);
+                }, this.info.comment.url(), true));
+            }
+            return result;
+        }
+
         public List<? extends Element> children() {return Lists.newArrayList(buttons);}
         public List<? extends Selectable> selectableChildren() {return Lists.newArrayList(buttons);}
     }
@@ -567,11 +584,19 @@ public abstract class MidnightConfig {
      */
     @Retention(RetentionPolicy.RUNTIME) @Target(ElementType.FIELD) public @interface Hidden {}
 
+    /**
+     * Comment Annotation<br>
+     * - <b>{@link Comment#centered()}</b>: If the comment should be centered (default: false)<br>
+     * - <b>{@link Comment#category()}</b>: The category of the comment in the config screen (default
+     * "default")<br>
+     * - <b>{@link Comment#name()}</b>: The name of the comment in the config screen (default: "")<br>
+     * - <b>{@link Comment#url()}</b>: The url of the comment in the config screen, empty or blank means no url (default: "")<br>
+     * */
     @Retention(RetentionPolicy.RUNTIME) @Target(ElementType.FIELD) public @interface Comment {
         boolean centered() default false;
         String category() default "default";
         String name() default "";
-        @Deprecated String requiredMod() default "";
+        String url() default "";
     }
     /**
      * Condition Annotation<br>

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ yarn_mappings=1.21.4+build.1
 enabled_platforms=fabric,neoforge
 
 archives_base_name=midnightlib
-mod_version=1.7.2-rc.1
+mod_version=1.7.2-rc.2
 maven_group=eu.midnightdust
 release_type=release
 curseforge_id=488090

--- a/test-fabric/src/main/java/eu/midnightdust/fabric/example/config/MidnightConfigExample.java
+++ b/test-fabric/src/main/java/eu/midnightdust/fabric/example/config/MidnightConfigExample.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 /** Every option in a MidnightConfig class has to be public and static, so we can access it from other classes.
  * The config class also has to extend MidnightConfig*/
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "DefaultAnnotationParam"})
 public class MidnightConfigExample extends MidnightConfig {
     public static final String TEXT = "text";
     public static final String NUMBERS = "numbers";
@@ -31,6 +31,8 @@ public class MidnightConfigExample extends MidnightConfig {
     public enum ModPlatform {                               // Enums allow the user to cycle through predefined options
         QUILT, FABRIC, FORGE, NEOFORGE, VANILLA
     }
+    @Comment(category = TEXT, name = "§nMidnightLib Wiki", centered = true, url = "https://www.midnightdust.eu/wiki/midnightlib/") public static Comment wiki; // Example for a comment with a url
+
     @Entry(category = NUMBERS) public static int fabric = 16777215;                 // Example for an int option
     @Entry(category = NUMBERS) public static double world = 1.4D;                   // Example for a double option
     @Entry(category = NUMBERS, min=69,max=420) public static int hello = 420;   // - The entered number has to be larger than 69 and smaller than 420


### PR DESCRIPTION
- feat: add clickable url for `@Comment`
- chore: bump version `1.7.2-rc.2`

```java
// other codes

@Comment(category = TEXT, name = "§nMidnightLib Wiki", centered = true, url = "https://www.midnightdust.eu/wiki/midnightlib/") 
public static Comment wiki; // Example for a comment with a url

// other codes
```

![image](https://github.com/user-attachments/assets/ee90b4e8-714f-45e9-9303-fa28e3bf83cd)
![image](https://github.com/user-attachments/assets/821867c4-237c-4b41-a7a4-50803c4f2b87)
