### PR TITLE
Respect TranslatableOption on enums

### DIFF
--- a/common/src/main/java/eu/midnightdust/lib/config/MidnightConfig.java
+++ b/common/src/main/java/eu/midnightdust/lib/config/MidnightConfig.java
@@ -15,6 +15,7 @@ import net.minecraft.registry.Registries;
 import net.minecraft.screen.ScreenTexts;
 import net.minecraft.text.Style; import net.minecraft.text.Text;
 import net.minecraft.util.Formatting; import net.minecraft.util.Identifier;
+import net.minecraft.util.TranslatableOption;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*; import javax.swing.filechooser.FileNameExtensionFilter;
@@ -170,10 +171,7 @@ public abstract class MidnightConfig {
                 }, func);
             } else if (info.dataType.isEnum()) {
                 List<?> values = Arrays.asList(field.getType().getEnumConstants());
-                Function<Object, Text> func = value -> {
-                    String translationKey = modid + ".midnightconfig.enum." + info.dataType.getSimpleName() + "." + info.toTemporaryValue();
-                    return I18n.hasTranslation(translationKey) ? Text.translatable(translationKey) : Text.literal(info.toTemporaryValue());
-                };
+                Function<Object, Text> func = value -> getEnumTranslatableText(value, modid, info);
                 info.function = new AbstractMap.SimpleEntry<ButtonWidget.PressAction, Function<Object, Text>>(button -> {
                     int index = values.indexOf(info.value) + 1;
                     info.setValue(values.get(index >= values.size() ? 0 : index));
@@ -193,6 +191,15 @@ public abstract class MidnightConfig {
     public static Tooltip getTooltip(EntryInfo info, boolean isButton) {
         String key = info.modid + ".midnightconfig."+info.fieldName+(!isButton ? ".label" : "" )+".tooltip";
         return Tooltip.of(isButton && info.error != null ? info.error : I18n.hasTranslation(key) ? Text.translatable(key) : Text.empty());
+    }
+
+    private static Text getEnumTranslatableText(Object value, String modid, EntryInfo info) {
+        if (value instanceof TranslatableOption translatableOption) {
+            return translatableOption.getText();
+        }
+
+        String translationKey = modid + ".midnightconfig.enum." + info.dataType.getSimpleName() + "." + info.toTemporaryValue();
+        return I18n.hasTranslation(translationKey) ? Text.translatable(translationKey) : Text.literal(info.toTemporaryValue());
     }
 
     private static void textField(EntryInfo info, Function<String,Number> f, Pattern pattern, double min, double max, boolean cast) {
@@ -359,8 +366,9 @@ public abstract class MidnightConfig {
                         Entry e = info.entry;
                         if (info.function instanceof Map.Entry) { // Enums & booleans
                             var values = (Map.Entry<ButtonWidget.PressAction, Function<Object, Text>>) info.function;
-                            if (info.dataType.isEnum())
-                                values.setValue(value -> Text.translatable(translationPrefix + "enum." + info.dataType.getSimpleName() + "." + info.value.toString()));
+                            if (info.dataType.isEnum()) {
+                                values.setValue(value -> getEnumTranslatableText(value, modid, info));
+                            }
                             widget = ButtonWidget.builder(values.getValue().apply(info.value), values.getKey()).dimensions(width - 185, 0, 150, 20).tooltip(getTooltip(info, true)).build();
                             if (info.dataType == boolean.class) info.actionButton = CheckboxWidget.builder(Text.empty(), textRenderer).callback((checkbox, checked) -> values.getKey().onPress((ButtonWidget) widget)).checked((Boolean) info.value).pos(widget.getX(), 1).build();
                         } else if (e.isSlider())

--- a/test-fabric/src/main/java/eu/midnightdust/fabric/example/config/MidnightConfigExample.java
+++ b/test-fabric/src/main/java/eu/midnightdust/fabric/example/config/MidnightConfigExample.java
@@ -2,7 +2,11 @@ package eu.midnightdust.fabric.example.config;
 
 import com.google.common.collect.Lists;
 import eu.midnightdust.lib.config.MidnightConfig;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.TranslatableOption;
 
 import javax.swing.*;
 import java.util.ArrayList;
@@ -31,6 +35,37 @@ public class MidnightConfigExample extends MidnightConfig {
     public enum ModPlatform {                               // Enums allow the user to cycle through predefined options
         QUILT, FABRIC, FORGE, NEOFORGE, VANILLA
     }
+    @Entry(category = TEXT) public static GraphicsSteps graphicsSteps = GraphicsSteps.FABULOUS;   // Example for an enum option with TranslatableOption
+    public enum GraphicsSteps implements TranslatableOption {
+        FAST(0, "options.graphics.fast"),
+        FANCY(1, "options.graphics.fancy"),
+        FABULOUS(2, "options.graphics.fabulous");
+
+        private final int id;
+        private final String translationKey;
+
+        GraphicsSteps(int id, String translationKey) {
+            this.id = id;
+            this.translationKey = translationKey;
+        }
+
+        @Override
+        public Text getText() {
+            MutableText mutableText = Text.translatable(this.getTranslationKey());
+            return this == GraphicsSteps.FABULOUS ? mutableText.formatted(Formatting.ITALIC).formatted(Formatting.AQUA) : mutableText;
+        }
+
+        @Override
+        public int getId() {
+            return this.id;
+        }
+
+        @Override
+        public String getTranslationKey() {
+            return this.translationKey;
+        }
+    }
+
     @Comment(category = TEXT, name = "§nMidnightLib Wiki", centered = true, url = "https://www.midnightdust.eu/wiki/midnightlib/") public static Comment wiki; // Example for a comment with a url
 
     @Entry(category = NUMBERS) public static int fabric = 16777215;                 // Example for an int option

--- a/test-fabric/src/main/resources/assets/modid/lang/en_us.json
+++ b/test-fabric/src/main/resources/assets/modid/lang/en_us.json
@@ -16,6 +16,7 @@
   "modid.midnightconfig.enum.ModPlatform.QUILT":"Quilt",
   "modid.midnightconfig.enum.ModPlatform.NEOFORGE":"NeoForge",
   "modid.midnightconfig.enum.ModPlatform.VANILLA":"Vanilla",
+  "modid.midnightconfig.graphicsSteps":"I am an enum with TranslatableOption!",
   "modid.midnightconfig.myFileOrDirectory.fileChooser": "Select an image or directory",
   "modid.midnightconfig.myFileOrDirectory.fileFilter": "Supported Images (.png, .jpg, .jpeg)",
   "modid.midnightconfig.category.numbers": "Numbers",


### PR DESCRIPTION
This PR makes it possible to use of built-in translation keys for enums and also style them, by checking if they implement `TranslatableOption`.

For example:
![grafik](https://github.com/user-attachments/assets/ab8653e4-bd9b-408d-90a3-c4d85deeb574)
