### PR TITLE
Fix bug & support comment format

### DIFF
--- a/src/main/java/eu/midnightdust/lib/config/EntryInfo.java
+++ b/src/main/java/eu/midnightdust/lib/config/EntryInfo.java
@@ -70,7 +70,7 @@ public class EntryInfo {
     public void updateFieldValue() {
         try {
             if (this.field.get(null) != value) MidnightConfig.entries.values().forEach(EntryInfo::updateConditions);
-            this.field.set(null, this.value);
+            if (this.entry != null) this.field.set(null, this.value);
         } catch (IllegalAccessException ignored) {
         }
     }

--- a/src/main/java/eu/midnightdust/lib/config/MidnightConfig.java
+++ b/src/main/java/eu/midnightdust/lib/config/MidnightConfig.java
@@ -4,6 +4,7 @@ import com.google.gson.*;
 import com.google.gson.stream.*;
 import eu.midnightdust.lib.util.PlatformFunctions;
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.screens.Screen;
@@ -216,13 +217,18 @@ public abstract class MidnightConfig {
             write(modid);
         }
 
-        entries.values().forEach(info -> {
+        entries.values().forEach((info) -> {
             if (info.field != null && info.entry != null) {
                 try {
-                    info.value = info.field.get(null) == null ? info.defaultValue : info.field.get(null);
+                    info.value = info.field.get(null) == null ?
+                            info.defaultValue : info.field.get(null);
                     info.tempValue = info.toTemporaryValue();
-                    info.updateConditions();
                 } catch (IllegalAccessException ignored) {}
+            }
+        });
+        entries.values().forEach((info) -> {
+            if (info.field != null && info.entry != null && Minecraft.getInstance() != null) {
+                Minecraft.getInstance().submit(info::updateConditions);  // use render thread to prevent IllegalAccessException
             }
         });
     }

--- a/src/main/java/eu/midnightdust/lib/config/MidnightConfigScreen.java
+++ b/src/main/java/eu/midnightdust/lib/config/MidnightConfigScreen.java
@@ -20,6 +20,7 @@ import net.minecraft.resources.Identifier;
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.*;
+import java.lang.reflect.Array;
 import java.util.*;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -295,12 +296,23 @@ public class MidnightConfigScreen extends Screen {
                     Object[] formatter = {};
                     try {
                         Object value = info.field.get(null);
-                        if (value instanceof Supplier supplier) {
+                        if (value instanceof Supplier<?> supplier) {
                              if (supplier.get() instanceof Object[] args) {
                                  formatter = args;
                              } else if (supplier.get() != null) {
                                  formatter = new Object[]{supplier.get()};
                              }
+                        } else if (value instanceof Iterable<?> iterable) {
+                            ArrayList<Object> list = new ArrayList<>();
+                            iterable.forEach(list::add);
+                            formatter = list.toArray();
+                        } else if (value != null && value.getClass().isArray()) {
+                            formatter = new Object[Array.getLength(value)];
+                            for (int i = 0; i < Array.getLength(value); i++) {
+                                formatter[i] = Array.get(value, i);
+                            }
+                        } else if (value != null) {
+                            formatter = new Object[]{value};
                         }
                     } catch (IllegalAccessException ignored) {}
                     this.list.addButton(List.of(), Component.translatable(info.translationKey, formatter), info);

--- a/src/main/java/eu/midnightdust/lib/config/MidnightConfigScreen.java
+++ b/src/main/java/eu/midnightdust/lib/config/MidnightConfigScreen.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 //? if >= 1.21.9 {
 import net.minecraft.client.input.KeyEvent;
 //?}
@@ -290,7 +291,20 @@ public class MidnightConfigScreen extends Screen {
                     }
                     if (!info.conditionsMet) widgets.forEach(w -> w.active = false);
                     this.list.addButton(widgets, Component.translatable(info.translationKey), info);
-                } else this.list.addButton(List.of(), Component.translatable(info.translationKey), info);
+                } else {
+                    Object[] formatter = {};
+                    try {
+                        Object value = info.field.get(null);
+                        if (value instanceof Supplier supplier) {
+                             if (supplier.get() instanceof Object[] args) {
+                                 formatter = args;
+                             } else if (supplier.get() != null) {
+                                 formatter = new Object[]{supplier.get()};
+                             }
+                        }
+                    } catch (IllegalAccessException ignored) {}
+                    this.list.addButton(List.of(), Component.translatable(info.translationKey, formatter), info);
+                }
             }
             list.setScrollAmount(scrollProgress);
             updateButtons();

--- a/src/test/java/eu/midnightdust/test/config/MidnightConfigExample.java
+++ b/src/test/java/eu/midnightdust/test/config/MidnightConfigExample.java
@@ -33,18 +33,18 @@ public class MidnightConfigExample extends MidnightConfig {
     public static final String EXTRAS = "extras";
 
     @Comment(category = TEXT, name = "§bUTC Time: %s")
-    public static final Supplier<Object[]> utcTime = () -> {                     // use the return value to format the comment
+    public static Supplier<Object[]> utcTime = () -> {                     // use the return value to format the comment
         Date now = new Date();
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
         return new Object[]{sdf.format(now)};
     };
     @Comment(category = TEXT, name = "OS: §6%s, Arch: §6%s")
-    public static final String[] platformInfo = {
+    public static String[] platformInfo = {
             System.getProperty("os.name"),
             System.getProperty("os.arch")
     };
     @Comment(category = TEXT, name = "Minecraft %s, %s mods loaded")
-    public static final List<String> gameInfo = List.of(
+    public static List<String> gameInfo = List.of(
         FabricLoader.getInstance().getRawGameVersion(),
         String.valueOf(FabricLoader.getInstance().getAllMods().size())
     );

--- a/src/test/java/eu/midnightdust/test/config/MidnightConfigExample.java
+++ b/src/test/java/eu/midnightdust/test/config/MidnightConfigExample.java
@@ -6,6 +6,7 @@ import eu.midnightdust.lib.config.MidnightConfigListWidget;
 import eu.midnightdust.lib.config.MidnightConfigScreen;
 import eu.midnightdust.test.MidnightLibExtras;
 import eu.midnightdust.lib.config.MidnightConfig;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.StringRepresentable;
@@ -31,12 +32,22 @@ public class MidnightConfigExample extends MidnightConfig {
     public static final String CONDITIONS = "conditions";
     public static final String EXTRAS = "extras";
 
-    @Comment(category = TEXT, name = "UTC Time: %s")
+    @Comment(category = TEXT, name = "§bUTC Time: %s")
     public static final Supplier<Object[]> utcTime = () -> {                     // use the return value to format the comment
         Date now = new Date();
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
         return new Object[]{sdf.format(now)};
     };
+    @Comment(category = TEXT, name = "OS: §6%s, Arch: §6%s")
+    public static final String[] platformInfo = {
+            System.getProperty("os.name"),
+            System.getProperty("os.arch")
+    };
+    @Comment(category = TEXT, name = "Minecraft %s, %s mods loaded")
+    public static final List<String> gameInfo = List.of(
+        FabricLoader.getInstance().getRawGameVersion(),
+        String.valueOf(FabricLoader.getInstance().getAllMods().size())
+    );
     @Comment(category = TEXT) public static Comment text1;                       // Comments are rendered like an option without a button and are excluded from the config file
     @Comment(category = TEXT, centered = true) public static Comment text2;      // Centered comments are the same as normal ones - just centered!
     @Comment(category = TEXT) public static Comment spacer1;                     // Comments containing the word "spacer" will just appear as a blank line

--- a/src/test/java/eu/midnightdust/test/config/MidnightConfigExample.java
+++ b/src/test/java/eu/midnightdust/test/config/MidnightConfigExample.java
@@ -11,9 +11,12 @@ import net.minecraft.resources.Identifier;
 import net.minecraft.util.StringRepresentable;
 
 import javax.swing.*;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /** Every option in a MidnightConfig class has to be public and static, so we can access it from other classes.
  * The config class also has to extend MidnightConfig
@@ -28,6 +31,12 @@ public class MidnightConfigExample extends MidnightConfig {
     public static final String CONDITIONS = "conditions";
     public static final String EXTRAS = "extras";
 
+    @Comment(category = TEXT, name = "UTC Time: %s")
+    public static final Supplier<Object[]> utcTime = () -> {                     // use the return value to format the comment
+        Date now = new Date();
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        return new Object[]{sdf.format(now)};
+    };
     @Comment(category = TEXT) public static Comment text1;                       // Comments are rendered like an option without a button and are excluded from the config file
     @Comment(category = TEXT, centered = true) public static Comment text2;      // Centered comments are the same as normal ones - just centered!
     @Comment(category = TEXT) public static Comment spacer1;                     // Comments containing the word "spacer" will just appear as a blank line


### PR DESCRIPTION
- fix #129
- use `Supplier<Object[]>` to format `@Comment`
    ```java
    @Comment(category = TEXT, name = "UTC Time: %s")
    public static final Supplier<Object[]> utcTime = () -> {  // use the return value to format the comment
        Date now = new Date();
        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
        return new Object[]{sdf.format(now)};
    };
    ```
    ![](https://github.com/user-attachments/assets/9634e95a-c2a1-4d50-8ce1-e7319eefeea5)
