### PR TITLE
add `register` which returns typed config instance, deprecate `init`

### DIFF
--- a/src/main/java/eu/midnightdust/core/MidnightLib.java
+++ b/src/main/java/eu/midnightdust/core/MidnightLib.java
@@ -72,7 +72,7 @@ public class MidnightLib {
                 UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
             }
         } catch (Exception | Error e) { LOGGER.error("Error setting system look and feel", e); }
-        MidnightLibConfig.init(MOD_ID, MidnightLibConfig.class);
+        MidnightLibConfig.register(MOD_ID, MidnightLibConfig.class);
     }
 
     //? if fabric {

--- a/src/main/java/eu/midnightdust/lib/config/MidnightConfig.java
+++ b/src/main/java/eu/midnightdust/lib/config/MidnightConfig.java
@@ -74,10 +74,9 @@ public abstract class MidnightConfig {
      * This is basically an argumented constructor without the requirement of having one in each config class.<br>
      * Not meant to be used externally.
      * */
-    protected static <T extends MidnightConfig> T createInstance(String modid, Class<? extends MidnightConfig> configClass) {
+    protected static <T extends MidnightConfig> T createInstance(String modid, Class<T> configClass) {
         try {
-            //noinspection unchecked
-            T instance = (T) configClass.getDeclaredConstructor().newInstance();
+            T instance = configClass.getDeclaredConstructor().newInstance();
             instance.modid = modid;
             instance.configClass = configClass;
             configInstances.put(modid, instance);
@@ -90,9 +89,11 @@ public abstract class MidnightConfig {
      * Initializes the config by registering all fields annotated with {@link Entry} or {@link Comment}<br>
      * @param modid Your mod's id
      * @param config The class containing your mod's config
+     *
+     * @return a newly created instance of the passed {@code config} class
      * */
-    public static void init(String modid, Class<? extends MidnightConfig> config) {
-        MidnightConfig instance = createInstance(modid, config);
+    public static <T extends MidnightConfig> T init(String modid, Class<T> config) {
+        T instance = createInstance(modid, config);
 
         for (Field field : config.getFields()) {
             if ((field.isAnnotationPresent(Entry.class) || field.isAnnotationPresent(Comment.class))
@@ -102,6 +103,8 @@ public abstract class MidnightConfig {
                 instance.addClientEntry(field, new EntryInfo(field, modid));
         }
         instance.loadValuesFromJson();
+
+        return instance;
     }
 
     /**

--- a/src/main/java/eu/midnightdust/lib/config/MidnightConfig.java
+++ b/src/main/java/eu/midnightdust/lib/config/MidnightConfig.java
@@ -92,7 +92,8 @@ public abstract class MidnightConfig {
      *
      * @return a newly created instance of the passed {@code config} class
      * */
-    public static <T extends MidnightConfig> T init(String modid, Class<T> config) {
+    @SuppressWarnings("UnusedReturnValue")
+    public static <T extends MidnightConfig> T register(String modid, Class<T> config) {
         T instance = createInstance(modid, config);
 
         for (Field field : config.getFields()) {
@@ -105,6 +106,16 @@ public abstract class MidnightConfig {
         instance.loadValuesFromJson();
 
         return instance;
+    }
+
+    /**
+     * Deprecated.
+     * <p>
+     * Use {@link #register(String, Class)} instead.
+     */
+    @Deprecated
+    public static void init(String modid, Class<? extends MidnightConfig> config) {
+        register(modid, config);
     }
 
     /**

--- a/src/test/java/eu/midnightdust/test/MidnightLibTest.java
+++ b/src/test/java/eu/midnightdust/test/MidnightLibTest.java
@@ -8,7 +8,7 @@ import net.fabricmc.api.ModInitializer;
 public class MidnightLibTest implements ModInitializer {
     @Override
     public void onInitialize() {
-        MidnightConfig.init("modid", MidnightConfigExample.class);
+        MidnightConfig.register("modid", MidnightConfigExample.class);
     }
 }
 //?}


### PR DESCRIPTION
Allows you to do this:
```java
return MidnightConfig.register(Meticulous.NAMESPACE, MidnightConfig.class);
```
instead of this:
```java
MidnightConfig.init(Meticulous.NAMESPACE, MidnightConfig.class);
return (MidnightConfig) configInstances.get(Meticulous.NAMESPACE);
```

Note: I tried running `gradlew check` but `1.20.1-fabric:compileTestJava` failed because of unresolved imports.